### PR TITLE
Implement circular queue for roads and add road management menu options

### DIFF
--- a/src/ConsoleUtils.java
+++ b/src/ConsoleUtils.java
@@ -1,12 +1,12 @@
-import java.io.IOException;
-
 public class ConsoleUtils {
     public static void clearConsole() {
         try {
-            var clearCommand = System.getProperty("os.name").contains("Windows")
-                    ? new ProcessBuilder("cmd", "/c", "cls")
-                    : new ProcessBuilder("clear");
-            clearCommand.inheritIO().start().waitFor();
-        } catch (IOException | InterruptedException ignored) {}
+            if (System.getProperty("os.name").contains("Windows")) {
+                new ProcessBuilder("cmd", "/c", "cls").inheritIO().start().waitFor();
+            } else {
+                System.out.print("\033[H\033[2J");
+                System.out.flush();
+            }
+        } catch (Exception e) {}
     }
 }

--- a/src/Menu.java
+++ b/src/Menu.java
@@ -1,3 +1,5 @@
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 public class Menu {
@@ -5,10 +7,15 @@ public class Menu {
 
     public Menu(Scanner scanner) {
         this.scanner = scanner;
+        System.setOut(new PrintStream(System.out, true, StandardCharsets.UTF_8));
     }
 
     public void call() {
-        TrafficManager trafficManager = createTrafficManagerFromUserInput();
+        System.out.println(Message.MSG_1);
+        System.out.print(Message.MSG_5);
+        int roads = Integer.parseInt(checkCorrectInput());
+        RoadQueue roadQueue = new RoadQueue(roads);
+        TrafficManager trafficManager = createTrafficManagerFromUserInput(roads, roadQueue);
         SystemState systemState = new SystemState(trafficManager);
         Thread queueThread = new Thread(systemState);
         queueThread.setName("QueueThread");
@@ -17,23 +24,23 @@ public class Menu {
         boolean isOn = true;
         do {
             System.out.println(Message.MSG_2);
-            chooseOption = scanner.nextLine();
+            chooseOption = scanner.nextLine().trim().replace("\r", "");
             switch (chooseOption) {
                 case "1" -> {
-                    trafficManager.addRoad();
-                    System.out.println();
+                    System.out.print("Input road name: ");
+                    String roadName = scanner.nextLine().trim().replace("\r", "");
+                    trafficManager.addRoad(roadName);
                     scanner.nextLine();
                     ConsoleUtils.clearConsole();
                 }
                 case "2" -> {
                     trafficManager.deleteRoad();
-                    System.out.println();
                     scanner.nextLine();
                     ConsoleUtils.clearConsole();
                 }
                 case "3" -> {
                     trafficManager.setCurrentState(State.SYSTEM);
-                    scanner.nextLine();
+                    scanner.nextLine().trim().replace("\r", "");
                     trafficManager.setCurrentState(State.MENU);
                     ConsoleUtils.clearConsole();
                 }
@@ -46,12 +53,11 @@ public class Menu {
                         Thread.currentThread().interrupt();
                         System.out.println("Main thread was interrupted while waiting for QueueThread to finish.");
                     }
-                    System.out.println(Message.MSG_12);
+                    System.out.println(Message.MSG_11);
                     System.out.println();
                 }
                 default -> {
                     System.out.println(Message.MSG_4);
-                    System.out.println();
                     scanner.nextLine();
                     ConsoleUtils.clearConsole();
                 }
@@ -59,35 +65,31 @@ public class Menu {
         } while (isOn);
     }
 
-    private TrafficManager createTrafficManagerFromUserInput() {
-        System.out.println(Message.MSG_1);
-        System.out.print(Message.MSG_5);
-        int roads = Integer.parseInt(checkCorrectInput());
-
+    private TrafficManager createTrafficManagerFromUserInput(int roads, RoadQueue roadQueue) {
         System.out.print(Message.MSG_6);
         int interval = Integer.parseInt(checkCorrectInput());
 
         ConsoleUtils.clearConsole();
 
-        return new TrafficManager(roads, interval);
+        return new TrafficManager(roads, interval, roadQueue);
     }
 
     private String checkCorrectInput() {
         boolean isNumeric;
-        String input = scanner.nextLine();
+        String input = scanner.nextLine().trim().replace("\r", "");
         try {
-            Integer.parseInt(input.trim());
+            Integer.parseInt(input);
             isNumeric = true;
-        } catch(NumberFormatException e){
+        } catch (NumberFormatException e) {
             isNumeric = false;
         }
-        while (!isNumeric || Integer.parseInt(input) == 0 || Integer.parseInt(input) < 0) {
+        while (!isNumeric || Integer.parseInt(input) <= 0) {
             System.out.print(Message.MSG_3);
-            input = scanner.nextLine();
+            input = scanner.nextLine().trim().replace("\r", "");
             try {
-                Integer.parseInt(input.trim());
+                Integer.parseInt(input);
                 isNumeric = true;
-            } catch(NumberFormatException e){
+            } catch (NumberFormatException e) {
                 isNumeric = false;
             }
         }

--- a/src/Message.java
+++ b/src/Message.java
@@ -10,12 +10,11 @@ public enum Message {
     MSG_4("Incorrect option"),
     MSG_5("Input the number of roads: "),
     MSG_6("Input the interval: "),
-    MSG_7("Road added"),
-    MSG_8("Road deleted"),
-    MSG_9("No more roads to delete!"),
-    MSG_10("System opened"),
-    MSG_11("System already opened"),
-    MSG_12("Bye!");
+    MSG_7(" Added!"),
+    MSG_8(" deleted"),
+    MSG_9("Queue is empty"),
+    MSG_10("Queue is full"),
+    MSG_11("Bye!");
 
     private final String message;
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,39 +1,25 @@
-# Traffic Light Simulator – Stage 4: Like a clockwork
+# Traffic Light Simulator – Stage 5: Over and over again
 
 ---
 
 ## 🧠 Description
 
-Creating a whole system at once is challenging, so we will start with a simple stopwatch in the new thread.
+Expand the created stopwatch into a road management system. Implement the circular queue that contains roads and add functionality to the remaining options in the menu.
 
-Let's assume that our program has three possible states:
-
-Not Started — the state until the initial settings have been provided;
-Menu — the state we worked with earlier. It shows possible options and processes the user's input;
-System — the state that shows the user information about our traffic light, such as time from startup and initial settings for now.
-When the user provided input for initial settings (both the number of roads and the interval), create a new thread to implement the System state. Name it as QueueThread by calling its setName() method with the corresponding string argument. The actions this newly-created thread should perform for now each second are:
-
-Increasing the variable that corresponds to the amount of time since the "system startup" each second (1000 milliseconds);
-(if in System state) Printing the system information.
-Let's add new functionality to the Open system menu option. By choosing 3 option in Menu, the program switches to the System state, and the main thread waits for input from the user. To return to the Menu state, the user should press Enter, in other words, an empty string should be provided as input.
-
-Example of system information output:
-
-```text
-! 3s. have passed since system startup !
-! Number of roads: 1 !
-! Interval: 1 !
-! Press "Enter" to open menu !
-```
 ---
 
 ## 🎯 Objectives
 
-Implement the System state as described above and set its thread name as `QueueThread`. While your program is in the System state, the output should contain the following information, updated (printing out) each second:
+In this stage, we will add functionality to the `Add road` and the `Delete road` options. Expand the `QueueThread` system by implementing a circular queue, where the maximum number of roads is the value provided in users' settings.
 
-- The line that shows the time since the program's start (contains only one integer — the number of seconds);
-- The line that indicates the number of roads provided by the user (includes the `number` substring and only one integer — the same value that was provided in the settings);
-- The line that shows the interval provided by the user (contains the `interval` substring and only one integer — the same value that was provided in the settings);
-- The line that asks the user to press Enter to open the menu (should contain the `Enter` substring)
-- 
-When the user provided an empty input, the program should switch back to the Menu state and show the previously implemented menu.
+When the user selects `1` as an option, print a line containing the `input` substring, followed by an input for a new element.
+
+- If the queue is full, the program should inform the user about that with the `queue is full` substring
+- Otherwise, add this element to the end of a queue and inform users with the `add` substring and the element's name
+
+When the user selects `2` as an option:
+
+- If the queue is empty, the program should inform users with the `queue is empty` substring
+- Otherwise, delete the element from the start of the queue and inform users with the `delete` substring and the element's name.
+
+Also, expand the output of the system information. If the queue is not empty, print all the elements' names line by line in the queue from front to rear.

--- a/src/RoadQueue.java
+++ b/src/RoadQueue.java
@@ -1,0 +1,78 @@
+import java.util.ArrayList;
+import java.util.List;
+
+public class RoadQueue {
+    private final int maxSize;
+    private final String[] queueArray;
+    private int front;
+    private int rear;
+    private int size;
+
+    public RoadQueue(int size) {
+        maxSize = size;
+        queueArray = new String[maxSize];
+        front = -1;
+        rear = -1;
+        this.size = 0;
+    }
+
+    public void enqueue(String item) {
+        if (size == maxSize) {
+            System.out.println(Message.MSG_10);
+            return;
+        }
+
+        if (isEmpty()) {
+            front = 0;
+            rear = 0;
+        } else {
+            rear = (rear + 1) % maxSize;
+        }
+
+        queueArray[rear] = item;
+        size++;
+        System.out.println(item + Message.MSG_7);
+    }
+
+    public void dequeue() {
+        if (isEmpty()) {
+            System.out.println(Message.MSG_9);
+            return;
+        }
+
+        String item = queueArray[front];
+        queueArray[front] = null;
+        size--;
+
+        System.out.println(item + Message.MSG_8);
+
+        if (isEmpty()) {
+            front = -1;
+            rear = -1;
+        } else {
+            front = (front + 1) % maxSize;
+        }
+
+    }
+
+    public List<String> getAll() {
+        if (isEmpty()) {
+            return List.of();
+        }
+
+        List<String> result = new ArrayList<>();
+        int current = front;
+        for (int i = 0; i < size; i++) {
+            if (queueArray[current] != null) {
+                result.add(queueArray[current]);
+            }
+            current = (current + 1) % maxSize;
+        }
+        return result;
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+}
+

--- a/src/SystemState.java
+++ b/src/SystemState.java
@@ -21,8 +21,9 @@ public class SystemState implements Runnable {
                     ConsoleUtils.clearConsole();
                     System.out.println("! " + timePassed + "s. have passed since system startup !");
                     System.out.println("! Number of roads: " + manager.getRoads() + " !");
-                    System.out.println("! Interval: " + manager.getInterval() + " !");
-                    System.out.println("! Press \"Enter\" to open menu !");
+                    System.out.println("! Interval: " + manager.getInterval() + " !\n");
+                    manager.getAllRoads().forEach(System.out::println);
+                    System.out.println("\n! Press \"Enter\" to open menu !");
                 }
             } catch (InterruptedException ignored) {}
         }

--- a/src/TrafficManager.java
+++ b/src/TrafficManager.java
@@ -1,30 +1,31 @@
+import java.util.List;
+
 public class TrafficManager {
-    private int roads;
+    private final int roads;
     private final int interval;
     private State currentState = State.NOT_STARTED;
+    private final RoadQueue roadQueue;
 
-
-    public TrafficManager(int roads, int interval) {
+    public TrafficManager(int roads, int interval, RoadQueue roadQueue) {
         this.roads = roads;
         this.interval = interval;
+        this.roadQueue = roadQueue;
     }
 
-    public void addRoad() {
-        roads++;
-        System.out.println(Message.MSG_7);
+    public void addRoad(String roadName) {
+        roadQueue.enqueue(roadName);
     }
 
     public void deleteRoad() {
-        if (roads > 0) {
-            roads--;
-            System.out.println(Message.MSG_8);
-        } else {
-            System.out.println(Message.MSG_9);
-        }
+        roadQueue.dequeue();
     }
 
     public int getRoads() {
         return roads;
+    }
+
+    public List<String> getAllRoads() {
+        return roadQueue.getAll();
     }
 
     public int getInterval() {


### PR DESCRIPTION
Expanded QueueThread with a circular queue to store roads up to the user-defined limit. Added "Add road" (option 1) and "Delete road" (option 2) functionality with appropriate messages for full or empty queue states. Updated system info output to display current roads in queue from front to rear when not empty.